### PR TITLE
Add a subset of the mapConfig tests from requirejs

### DIFF
--- a/tests/mapConfig/a1.js
+++ b/tests/mapConfig/a1.js
@@ -1,0 +1,6 @@
+define(['c', 'c/sub'], function (c, csub) {
+    return {
+        c: c,
+        csub: csub
+    };
+});

--- a/tests/mapConfig/a1/sub/one.js
+++ b/tests/mapConfig/a1/sub/one.js
@@ -1,0 +1,6 @@
+define(['c', 'c/sub'], function (c, csub) {
+    return {
+        c: c,
+        csub: csub
+    };
+});

--- a/tests/mapConfig/adapter/d.js
+++ b/tests/mapConfig/adapter/d.js
@@ -1,0 +1,4 @@
+define(['d'], function(d) {
+    d.adapted = true;
+    return d;
+});

--- a/tests/mapConfig/another/c.js
+++ b/tests/mapConfig/another/c.js
@@ -1,0 +1,6 @@
+define(['./minor'], function (minor) {
+    return {
+        name: 'another/c',
+        minorName: minor.name
+    };
+});

--- a/tests/mapConfig/another/c/dim.js
+++ b/tests/mapConfig/another/c/dim.js
@@ -1,0 +1,3 @@
+define({
+    name: 'another/c/dim'
+});

--- a/tests/mapConfig/another/c/sub.js
+++ b/tests/mapConfig/another/c/sub.js
@@ -1,0 +1,6 @@
+define(['./dim'], function (dim) {
+    return {
+        name: 'another/c/sub',
+        dimName: dim.name
+    };
+});

--- a/tests/mapConfig/another/minor.js
+++ b/tests/mapConfig/another/minor.js
@@ -1,0 +1,4 @@
+define({
+    name: 'another/minor'
+});
+

--- a/tests/mapConfig/b.js
+++ b/tests/mapConfig/b.js
@@ -1,0 +1,6 @@
+define(['c', 'c/sub'], function (c, csub) {
+    return {
+        c: c,
+        csub: csub
+    };
+});

--- a/tests/mapConfig/c.js
+++ b/tests/mapConfig/c.js
@@ -1,0 +1,3 @@
+define({
+    name: 'c'
+});

--- a/tests/mapConfig/c/sub.js
+++ b/tests/mapConfig/c/sub.js
@@ -1,0 +1,3 @@
+define({
+    name: 'c/sub'
+});

--- a/tests/mapConfig/c1.js
+++ b/tests/mapConfig/c1.js
@@ -1,0 +1,3 @@
+define({
+    name: 'c1'
+});

--- a/tests/mapConfig/c1/sub.js
+++ b/tests/mapConfig/c1/sub.js
@@ -1,0 +1,3 @@
+define({
+    name: 'c1/sub'
+});

--- a/tests/mapConfig/c2.js
+++ b/tests/mapConfig/c2.js
@@ -1,0 +1,3 @@
+define({
+    name: 'c2'
+});

--- a/tests/mapConfig/c2/sub.js
+++ b/tests/mapConfig/c2/sub.js
@@ -1,0 +1,3 @@
+define({
+    name: 'c2/sub'
+});

--- a/tests/mapConfig/d.js
+++ b/tests/mapConfig/d.js
@@ -1,0 +1,3 @@
+define({
+    name: 'd'
+});

--- a/tests/mapConfig/e.js
+++ b/tests/mapConfig/e.js
@@ -1,0 +1,6 @@
+define(['d'], function (d) {
+    return {
+        name: 'e',
+        d: d
+    };
+});

--- a/tests/mapConfig/mapConfig-tests.js
+++ b/tests/mapConfig/mapConfig-tests.js
@@ -1,0 +1,33 @@
+config({
+    baseUrl: './',
+    paths: {
+        a: 'a1'
+    },
+    map: {
+        'a': {
+            c: 'c1'
+        },
+        'a/sub/one': {
+            'c': 'c2'
+        }
+    }
+});
+go(['a', 'b', 'c', 'a/sub/one'],
+    function(a, b, c, one) {
+        doh.register(
+            'mapConfig',
+            [
+                function mapConfig(t){
+                    t.is('c1', a.c.name);
+                    t.is('c1/sub', a.csub.name);
+                    t.is('c2', one.c.name);
+                    t.is('c2/sub', one.csub.name);
+                    t.is('c', b.c.name);
+                    t.is('c/sub', b.csub.name);
+                    t.is('c', c.name);
+                }
+            ]
+        );
+        doh.run();
+    }
+);

--- a/tests/mapConfig/mapConfig.html
+++ b/tests/mapConfig/mapConfig.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>require.js: Map Config Test</title>
+    <title>Map Config Test</title>
     <script type="text/javascript" src="../bootstrap.js"></script>
     <script type="text/javascript" src="mapConfig-tests.js"></script>
 </head>
 <body>
-    <h1>require.js: Map Config Test</h1>
+    <h1>Map Config Test</h1>
     <p>Test using the map config.</p>
     <p>Check console for messages</p>
 </body>

--- a/tests/mapConfig/mapConfig.html
+++ b/tests/mapConfig/mapConfig.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>require.js: Map Config Test</title>
+    <script type="text/javascript" src="../bootstrap.js"></script>
+    <script type="text/javascript" src="mapConfig-tests.js"></script>
+</head>
+<body>
+    <h1>require.js: Map Config Test</h1>
+    <p>Test using the map config.</p>
+    <p>Check console for messages</p>
+</body>
+</html>

--- a/tests/mapConfig/mapConfigStar-tests.js
+++ b/tests/mapConfig/mapConfigStar-tests.js
@@ -1,0 +1,41 @@
+config({
+    baseUrl: './',
+    paths: {
+        a: 'a1'
+    },
+
+    map: {
+        '*': {
+            'c': 'another/c'
+        },
+        'a': {
+            c: 'c1'
+        },
+        'a/sub/one': {
+            'c': 'c2',
+            'c/sub': 'another/c/sub'
+        }
+    }
+});
+go(['a', 'b', 'c', 'a/sub/one'],
+    function(a, b, c, one) {
+        doh.register(
+            'mapConfigStar',
+            [
+                function mapConfigStar(t){
+                    t.is('c1', a.c.name);
+                    t.is('c1/sub', a.csub.name);
+                    t.is('c2', one.c.name);
+                    t.is('another/c/sub', one.csub.name);
+                    t.is('another/c/dim', one.csub.dimName);
+                    t.is('another/c', b.c.name);
+                    t.is('another/minor', b.c.minorName);
+                    t.is('another/c/sub', b.csub.name);
+                    t.is('another/c', c.name);
+                    t.is('another/minor', c.minorName);
+                }
+            ]
+        );
+        doh.run();
+    }
+);

--- a/tests/mapConfig/mapConfigStar.html
+++ b/tests/mapConfig/mapConfigStar.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>require.js: Map Config Star Test</title>
+    <script type="text/javascript" src="../bootstrap.js"></script>
+    <script type="text/javascript" src="mapConfigStar-tests.js"></script>
+</head>
+<body>
+    <h1>require.js: Map Config Star Test</h1>
+    <p>Test using '*' in the map config.</p>
+    <p>Check console for messages</p>
+</body>
+</html>

--- a/tests/mapConfig/mapConfigStar.html
+++ b/tests/mapConfig/mapConfigStar.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>require.js: Map Config Star Test</title>
+    <title>Map Config Star Test</title>
     <script type="text/javascript" src="../bootstrap.js"></script>
     <script type="text/javascript" src="mapConfigStar-tests.js"></script>
 </head>
 <body>
-    <h1>require.js: Map Config Star Test</h1>
+    <h1>Map Config Star Test</h1>
     <p>Test using '*' in the map config.</p>
     <p>Check console for messages</p>
 </body>

--- a/tests/mapConfig/mapConfigStarAdapter-tests.js
+++ b/tests/mapConfig/mapConfigStarAdapter-tests.js
@@ -1,0 +1,30 @@
+/*global doh */
+config({
+    baseUrl: './',
+    map: {
+        '*': {
+            'd': 'adapter/d'
+        },
+        'adapter/d': {
+            d: 'd'
+        }
+    }
+});
+go(['e', 'adapter/d'],
+    function(e, adapterD) {
+        'use strict';
+        doh.register(
+            'mapConfigStarAdapter',
+            [
+                function mapConfigStarAdapter(t){
+                    t.is('e', e.name);
+                    t.is('d', e.d.name);
+                    t.is(true, e.d.adapted);
+                    t.is(true, adapterD.adapted);
+                    t.is('d', adapterD.name);
+                }
+            ]
+        );
+        doh.run();
+    }
+);

--- a/tests/mapConfig/mapConfigStarAdapter.html
+++ b/tests/mapConfig/mapConfigStarAdapter.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>require.js: Map Config Star Swap Test</title>
+    <script type="text/javascript" src="../bootstrap.js"></script>
+    <script type="text/javascript" src="mapConfigStarAdapter-tests.js"></script>
+</head>
+<body>
+    <h1>require.js: Map Config Star Swap Test</h1>
+    <p>Test using '*' in the map config, but with an adapter module
+    that is used to load the non-* version and add to it. More info:
+    <a href="https://github.com/jrburke/requirejs/issues/277">#277</a></p>
+
+    <p>Check console for messages</p>
+</body>
+</html>

--- a/tests/mapConfig/mapConfigStarAdapter.html
+++ b/tests/mapConfig/mapConfigStarAdapter.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>require.js: Map Config Star Swap Test</title>
+    <title>Map Config Star Swap Test</title>
     <script type="text/javascript" src="../bootstrap.js"></script>
     <script type="text/javascript" src="mapConfigStarAdapter-tests.js"></script>
 </head>
 <body>
-    <h1>require.js: Map Config Star Swap Test</h1>
+    <h1>Map Config Star Swap Test</h1>
     <p>Test using '*' in the map config, but with an adapter module
     that is used to load the non-* version and add to it. More info:
     <a href="https://github.com/jrburke/requirejs/issues/277">#277</a></p>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -10,7 +10,8 @@
             'namedWrapped',
             'require',
             'plugins',
-            'pluginDynamic'
+            'pluginDynamic',
+            'mapConfig'
         ],
         i, levels, name;
 
@@ -54,8 +55,13 @@
         pluginDynamic: function () {
             reg('plugins/dynamic');
             reg('plugins/dynamicToString');
-        }
+        },
 
+		mapConfig: function () {
+            reg('mapConfig/mapConfig');
+            reg('mapConfig/mapConfigStar');
+            reg('mapConfig/mapConfigStarAdapter');
+		}
 
         //basic: true, //include require, exports, module tests.
         //anonymous: true, //include function callback and basic object callback,


### PR DESCRIPTION
Add a subset of the mapConfig tests from requirejs. I have copied 3 tests and converted them to run in a similar manor to the other amdjs tests. The 3 tests are "mapConfig", "mapConfigStar" and "mapConfigStarAdapter".
