### PR TITLE
Resolve Issue 13 anon_relative and adds config_path_relative test

### DIFF
--- a/impl/inject/config.js
+++ b/impl/inject/config.js
@@ -26,7 +26,7 @@ var config = function(pathObj) {
         funcString: true,
         namedWrapped: true,
         require: true,
-        plugins: true
-        // pluginDynamic: true
+        plugins: true,
+        pathsConfig: true
     };
 require = undefined;

--- a/server/resources/all.html
+++ b/server/resources/all.html
@@ -101,6 +101,9 @@
         <li class="pathsConfig" id="config_paths"><a href="/{{FRAMEWORK}}/config_paths/test.html">
           config_paths: test for the "path" functionality of Common Config
         </a></li>
+        <li class="pathsConfig" id="config_paths"><a href="/{{FRAMEWORK}}/config_paths_relative/test.html">
+          config_paths_relative: ensure that the relative module ID rules still apply, even when using the path config</a></li>
+        </a></li>
       </ul>
     </li>
 

--- a/tests/anon_relative/_test.js
+++ b/tests/anon_relative/_test.js
@@ -1,12 +1,7 @@
-config({
-  paths: {
-    "array": "impl/array"
-  }
-});
-
-go(     ["_reporter", "require", "array"],
+go(     ["_reporter", "require", "impl/array"],
 function (amdJS,       require,   array) {
     amdJS.assert('impl/array' === array.name, 'anon_relative: array.name');
-    amdJS.assert('util' === array.utilName, 'anon_relative: relative to module ID, not URL');
+    amdJS.assert('impl/util' === array.dotUtilName, 'anon_relative: resolved "./util" to impl/util');
+    amdJS.assert('util' === array.utilName, 'anon_relative: resolved "util" to impl/util');
     amdJS.print('DONE', 'done');
 });

--- a/tests/anon_relative/impl/array.js
+++ b/tests/anon_relative/impl/array.js
@@ -1,6 +1,7 @@
-define(['./util'], function (util) {
+define(['./util', 'util'], function (dotUtil, util) {
     return {
         name: 'impl/array',
+        dotUtilName: dotUtil.name,
         utilName: util.name
     };
 });

--- a/tests/config_paths_relative/_reporter.js
+++ b/tests/config_paths_relative/_reporter.js
@@ -1,0 +1,31 @@
+// _reporter.js
+(function() {
+  var factory = function () {
+    var exports = {};
+
+    exports.print = function () {
+      // global print
+      if (typeof amdJSPrint !== "undefined") {
+        amdJSPrint.apply(undefined, arguments);
+      }
+      else {
+        var stdout = require("system").stdout;
+        stdout.print.apply(stdout, arguments);
+      }
+    };
+
+    exports.assert = function (guard, message) {
+      if (guard) {
+        exports.print("PASS " + message, "pass");
+      } else {
+        exports.print("FAIL " + message, "fail");
+      }
+    };
+
+    return exports;
+  };
+
+  // define this module
+  define("_reporter", [], factory);
+
+})();

--- a/tests/config_paths_relative/_test.js
+++ b/tests/config_paths_relative/_test.js
@@ -1,0 +1,12 @@
+config({
+  paths: {
+    "array": "impl/array"
+  }
+});
+
+go(     ["_reporter", "require", "array"],
+function (amdJS,       require,   array) {
+    amdJS.assert('impl/array' === array.name, 'anon_relative: array.name');
+    amdJS.assert('util' === array.utilName, 'anon_relative: relative to module ID, not URL');
+    amdJS.print('DONE', 'done');
+});

--- a/tests/config_paths_relative/impl/array.js
+++ b/tests/config_paths_relative/impl/array.js
@@ -1,0 +1,6 @@
+define(['./util'], function (util) {
+    return {
+        name: 'impl/array',
+        utilName: util.name
+    };
+});

--- a/tests/config_paths_relative/impl/util.js
+++ b/tests/config_paths_relative/impl/util.js
@@ -1,0 +1,3 @@
+define({
+    name: 'impl/util'
+});

--- a/tests/config_paths_relative/util.js
+++ b/tests/config_paths_relative/util.js
@@ -1,0 +1,3 @@
+define({
+    name: 'util'
+});


### PR DESCRIPTION
The original anon_relative was using logic required by config_path
in order to properly test the relative path information. To remedy,
the anon_relative has the path information removed, and a new test
config_path_relative was created as part of the configPaths suite.
This test ensures that relative modules remain relative to their
module ID and not to their URL, even in the event of a path remap.

Github ID: #13
