### PR TITLE
Issue 14 create a basicEmpty class of tests that test no deps

### DIFF
--- a/impl/inject/config.js
+++ b/impl/inject/config.js
@@ -22,6 +22,7 @@ var config = function(pathObj) {
     },
     implemented = {
         basic: true,
+        basicEmpty: true,
         anon: true,
         funcString: true,
         namedWrapped: true,

--- a/impl/lsjs/config.js
+++ b/impl/lsjs/config.js
@@ -9,12 +9,12 @@ localStorage.clear();
 var config = lsjs,
     go = lsjs,
     implemented = {
-		basic: true,
-		anon: true,
-		funcString: true,
-        namedWrapped: true,
-		require: true,
-		plugins: true
-		//pluginDynamic: true
+    basic: true,
+    anon: true,
+    funcString: true,
+    namedWrapped: true,
+    require: true,
+    plugins: true
+    //pluginDynamic: true
     };
 require = undefined;

--- a/impl/needs/config.js
+++ b/impl/needs/config.js
@@ -1,13 +1,14 @@
 var go = require,
-	config = require.config,
-	implemented = {
-		basic: true,
-		anon: true,
-		require: true,
-		funcString: true,
-		namedWrapped: true,
-		plugins: true,
-		pluginDynamic: false
-	};
+  config = require.config,
+  implemented = {
+    basic: true,
+    basicEmpty: true,
+    anon: true,
+    require: true,
+    funcString: true,
+    namedWrapped: true,
+    plugins: true,
+    pluginDynamic: false
+  };
 
 require = undefined;

--- a/impl/sample.js
+++ b/impl/sample.js
@@ -1,0 +1,34 @@
+/*
+These are all the currently supported tests
+
+Use it as a template for your own impl
+*/
+
+var config, go, implemented;
+
+// config is a way to set up configuration for AMD tests
+config = function () {};
+
+// map this to your loader's entry point
+go = function () {};
+
+// comment out the tests you don't need
+implemented = {
+  basic: true,
+  basicEmpty: true,
+  anon: true,
+  funcString: true,
+  namedWrapped: true,
+  require: true,
+
+  // plugin support
+  plugins: true,
+  pluginDynamic: true,
+
+  // config proposal
+  pathsConfig: true,
+  packagesConfig: true,
+  mapConfig: true,
+  moduleConfig: true,
+  shimConfig: true
+};

--- a/server/resources/all.html
+++ b/server/resources/all.html
@@ -47,6 +47,9 @@
         <li class="basic" id="basic_simple"><a href="/{{FRAMEWORK}}/basic_simple/test.html">
           basic_simple: amd simple includes for named AMD modules
         </a></li>
+        <li class="basicEmpty" id="basic_empty_deps"><a href="/{{FRAMEWORK}}/basic_empty_deps/test.html">
+          basic_empty_defs: [] should imply no dependencies, while an empty "dependencies" variable defaults to require, exports, module
+        </a></li>
       </ul>
     </li>
 

--- a/tests/basic_empty_deps/_reporter.js
+++ b/tests/basic_empty_deps/_reporter.js
@@ -1,0 +1,31 @@
+// _reporter.js
+(function() {
+  var factory = function () {
+    var exports = {};
+
+    exports.print = function () {
+      // global print
+      if (typeof amdJSPrint !== "undefined") {
+        amdJSPrint.apply(undefined, arguments);
+      }
+      else {
+        var stdout = require("system").stdout;
+        stdout.print.apply(stdout, arguments);
+      }
+    };
+
+    exports.assert = function (guard, message) {
+      if (guard) {
+        exports.print("PASS " + message, "pass");
+      } else {
+        exports.print("FAIL " + message, "fail");
+      }
+    };
+
+    return exports;
+  };
+
+  // define this module
+  define("_reporter", [], factory);
+
+})();

--- a/tests/basic_empty_deps/_test.js
+++ b/tests/basic_empty_deps/_test.js
@@ -1,0 +1,33 @@
+go(["_reporter", "require"], function(amdJS, require) {
+
+  function emptyDeps(then) {
+    define('emptyDeps', [], function() {
+      amdJS.assert(arguments.length === 0, 'basic_empty_deps: [] should be treated as no dependencies instead of the default require, exports, module');
+      then();
+    });
+  }
+
+  function noDeps(then) {
+    define('noDeps', function(require, exports, module) {
+      amdJS.assert(typeof(require) === 'function', 'basic_empty_deps: no dependencies case uses require in first slot. Is a function');
+      amdJS.assert(typeof(exports) === 'object', 'basic_empty_deps: no dependencies case uses exports in second slot. Is an object.');
+      amdJS.assert(typeof(module) === 'object', 'basic_empty_deps: no dependencies case uses module in third slot. Is an object.');
+      then();
+    });
+  }
+
+  // this nesting structure ensures that the AMD define will resolve
+  // before we call the next by after the tests are ran in each use
+  // case. We use named define calls to ensure there are not module
+  // conflicts or mismatches that can occur using anonymous modules.
+  emptyDeps(function () {
+    window.setTimeout(function () {
+      noDeps(function () {
+        window.setTimeout(function () {
+          amdJS.print('DONE', 'done');
+        });
+      });
+    });
+  });
+  
+});


### PR DESCRIPTION
Issue #14 references a situation where an empty dependency array
denoted by [] should return no dependencies (as opposed to the
normal require/exports/module combination). A define() call that
does not contain any dependencies should receive the default
require/module/exports combination.

Compliance passing libs were opted in.

A sample.js file was created to help new impl developers follow a template for adding their own libraries.
