### PR TITLE
Spec test update for define without dependencies, correction for anon_relative

### DIFF
--- a/impl/inject/config.js
+++ b/impl/inject/config.js
@@ -22,7 +22,6 @@ var config = function(pathObj) {
     },
     implemented = {
         basic: true,
-        basicEmpty: true,
         anon: true,
         funcString: true,
         namedWrapped: true,

--- a/impl/inject/config.js
+++ b/impl/inject/config.js
@@ -22,6 +22,7 @@ var config = function(pathObj) {
     },
     implemented = {
         basic: true,
+        basicEmpty: true,
         anon: true,
         funcString: true,
         namedWrapped: true,

--- a/impl/inject/config.js
+++ b/impl/inject/config.js
@@ -26,7 +26,7 @@ var config = function(pathObj) {
         funcString: true,
         namedWrapped: true,
         require: true,
-        plugins: true
-        // pluginDynamic: true
+        plugins: true,
+        pathsConfig: true
     };
 require = undefined;

--- a/impl/lsjs/config.js
+++ b/impl/lsjs/config.js
@@ -9,12 +9,12 @@ localStorage.clear();
 var config = lsjs,
     go = lsjs,
     implemented = {
-		basic: true,
-		anon: true,
-		funcString: true,
-        namedWrapped: true,
-		require: true,
-		plugins: true
-		//pluginDynamic: true
+    basic: true,
+    anon: true,
+    funcString: true,
+    namedWrapped: true,
+    require: true,
+    plugins: true
+    //pluginDynamic: true
     };
 require = undefined;

--- a/impl/lsjs/config.js
+++ b/impl/lsjs/config.js
@@ -9,12 +9,13 @@ localStorage.clear();
 var config = lsjs,
     go = lsjs,
     implemented = {
-    basic: true,
-    anon: true,
-    funcString: true,
-    namedWrapped: true,
-    require: true,
-    plugins: true
-    //pluginDynamic: true
+      // SEE: tests/basic_empty_deps
+      // basic: true,
+      anon: true,
+      funcString: true,
+      namedWrapped: true,
+      require: true,
+      plugins: true
+      //pluginDynamic: true
     };
 require = undefined;

--- a/impl/needs/config.js
+++ b/impl/needs/config.js
@@ -2,7 +2,6 @@ var go = require,
   config = require.config,
   implemented = {
     basic: true,
-    basicEmpty: true,
     anon: true,
     require: true,
     funcString: true,

--- a/impl/needs/config.js
+++ b/impl/needs/config.js
@@ -1,13 +1,14 @@
 var go = require,
-	config = require.config,
-	implemented = {
-		basic: true,
-		anon: true,
-		require: true,
-		funcString: true,
-		namedWrapped: true,
-		plugins: true,
-		pluginDynamic: false
-	};
+  config = require.config,
+  implemented = {
+    basic: true,
+    basicEmpty: true,
+    anon: true,
+    require: true,
+    funcString: true,
+    namedWrapped: true,
+    plugins: true,
+    pluginDynamic: false
+  };
 
 require = undefined;

--- a/impl/requirejs/config.js
+++ b/impl/requirejs/config.js
@@ -8,7 +8,8 @@ var config = require,
     //Indicate what levels of the API are implemented by this loader,
     //and therefore which tests to run.
     implemented = {
-        basic: true,
+        // SEE: tests/basic_empty_deps
+        // basic: true,
         anon: true,
         funcString: true,
         namedWrapped: true,

--- a/impl/sample.js
+++ b/impl/sample.js
@@ -15,7 +15,6 @@ go = function () {};
 // comment out the tests you don't need
 implemented = {
   basic: true,
-  basicEmpty: true,
   anon: true,
   funcString: true,
   namedWrapped: true,

--- a/impl/sample.js
+++ b/impl/sample.js
@@ -1,0 +1,34 @@
+/*
+These are all the currently supported tests
+
+Use it as a template for your own impl
+*/
+
+var config, go, implemented;
+
+// config is a way to set up configuration for AMD tests
+config = function () {};
+
+// map this to your loader's entry point
+go = function () {};
+
+// comment out the tests you don't need
+implemented = {
+  basic: true,
+  basicEmpty: true,
+  anon: true,
+  funcString: true,
+  namedWrapped: true,
+  require: true,
+
+  // plugin support
+  plugins: true,
+  pluginDynamic: true,
+
+  // config proposal
+  pathsConfig: true,
+  packagesConfig: true,
+  mapConfig: true,
+  moduleConfig: true,
+  shimConfig: true
+};

--- a/server/resources/all.html
+++ b/server/resources/all.html
@@ -101,6 +101,9 @@
         <li class="pathsConfig" id="config_paths"><a href="/{{FRAMEWORK}}/config_paths/test.html">
           config_paths: test for the "path" functionality of Common Config
         </a></li>
+        <li class="pathsConfig" id="config_paths"><a href="/{{FRAMEWORK}}/config_paths_relative/test.html">
+          config_paths_relative: ensure that the relative module ID rules still apply, even when using the path config</a></li>
+        </a></li>
       </ul>
     </li>
 

--- a/server/resources/all.html
+++ b/server/resources/all.html
@@ -47,6 +47,9 @@
         <li class="basic" id="basic_simple"><a href="/{{FRAMEWORK}}/basic_simple/test.html">
           basic_simple: amd simple includes for named AMD modules
         </a></li>
+        <li class="basicEmpty" id="basic_empty_deps"><a href="/{{FRAMEWORK}}/basic_empty_deps/test.html">
+          basic_empty_defs: [] should imply no dependencies, while an empty "dependencies" variable defaults to require, exports, module
+        </a></li>
       </ul>
     </li>
 

--- a/server/resources/all.html
+++ b/server/resources/all.html
@@ -47,7 +47,7 @@
         <li class="basic" id="basic_simple"><a href="/{{FRAMEWORK}}/basic_simple/test.html">
           basic_simple: amd simple includes for named AMD modules
         </a></li>
-        <li class="basicEmpty" id="basic_empty_deps"><a href="/{{FRAMEWORK}}/basic_empty_deps/test.html">
+        <li class="basic" id="basic_empty_deps"><a href="/{{FRAMEWORK}}/basic_empty_deps/test.html">
           basic_empty_defs: [] should imply no dependencies, while an empty "dependencies" variable defaults to require, exports, module
         </a></li>
       </ul>

--- a/tests/anon_relative/_test.js
+++ b/tests/anon_relative/_test.js
@@ -1,12 +1,7 @@
-config({
-  paths: {
-    "array": "impl/array"
-  }
-});
-
-go(     ["_reporter", "require", "array"],
+go(     ["_reporter", "require", "impl/array"],
 function (amdJS,       require,   array) {
     amdJS.assert('impl/array' === array.name, 'anon_relative: array.name');
-    amdJS.assert('util' === array.utilName, 'anon_relative: relative to module ID, not URL');
+    amdJS.assert('impl/util' === array.dotUtilName, 'anon_relative: resolved "./util" to impl/util');
+    amdJS.assert('util' === array.utilName, 'anon_relative: resolved "util" to impl/util');
     amdJS.print('DONE', 'done');
 });

--- a/tests/anon_relative/impl/array.js
+++ b/tests/anon_relative/impl/array.js
@@ -1,6 +1,7 @@
-define(['./util'], function (util) {
+define(['./util', 'util'], function (dotUtil, util) {
     return {
         name: 'impl/array',
+        dotUtilName: dotUtil.name,
         utilName: util.name
     };
 });

--- a/tests/basic_empty_deps/_reporter.js
+++ b/tests/basic_empty_deps/_reporter.js
@@ -1,0 +1,31 @@
+// _reporter.js
+(function() {
+  var factory = function () {
+    var exports = {};
+
+    exports.print = function () {
+      // global print
+      if (typeof amdJSPrint !== "undefined") {
+        amdJSPrint.apply(undefined, arguments);
+      }
+      else {
+        var stdout = require("system").stdout;
+        stdout.print.apply(stdout, arguments);
+      }
+    };
+
+    exports.assert = function (guard, message) {
+      if (guard) {
+        exports.print("PASS " + message, "pass");
+      } else {
+        exports.print("FAIL " + message, "fail");
+      }
+    };
+
+    return exports;
+  };
+
+  // define this module
+  define("_reporter", [], factory);
+
+})();

--- a/tests/basic_empty_deps/_test.js
+++ b/tests/basic_empty_deps/_test.js
@@ -1,0 +1,33 @@
+go(["_reporter", "require"], function(amdJS, require) {
+
+  function emptyDeps(then) {
+    define('emptyDeps', [], function() {
+      amdJS.assert(arguments.length === 0, 'basic_empty_deps: [] should be treated as no dependencies instead of the default require, exports, module');
+      then();
+    });
+  }
+
+  function noDeps(then) {
+    define('noDeps', function(require, exports, module) {
+      amdJS.assert(typeof(require) === 'function', 'basic_empty_deps: no dependencies case uses require in first slot. Is a function');
+      amdJS.assert(typeof(exports) === 'object', 'basic_empty_deps: no dependencies case uses exports in second slot. Is an object.');
+      amdJS.assert(typeof(module) === 'object', 'basic_empty_deps: no dependencies case uses module in third slot. Is an object.');
+      then();
+    });
+  }
+
+  // this nesting structure ensures that the AMD define will resolve
+  // before we call the next by after the tests are ran in each use
+  // case. We use named define calls to ensure there are not module
+  // conflicts or mismatches that can occur using anonymous modules.
+  emptyDeps(function () {
+    window.setTimeout(function () {
+      noDeps(function () {
+        window.setTimeout(function () {
+          amdJS.print('DONE', 'done');
+        });
+      });
+    });
+  });
+  
+});

--- a/tests/config_paths_relative/_reporter.js
+++ b/tests/config_paths_relative/_reporter.js
@@ -1,0 +1,31 @@
+// _reporter.js
+(function() {
+  var factory = function () {
+    var exports = {};
+
+    exports.print = function () {
+      // global print
+      if (typeof amdJSPrint !== "undefined") {
+        amdJSPrint.apply(undefined, arguments);
+      }
+      else {
+        var stdout = require("system").stdout;
+        stdout.print.apply(stdout, arguments);
+      }
+    };
+
+    exports.assert = function (guard, message) {
+      if (guard) {
+        exports.print("PASS " + message, "pass");
+      } else {
+        exports.print("FAIL " + message, "fail");
+      }
+    };
+
+    return exports;
+  };
+
+  // define this module
+  define("_reporter", [], factory);
+
+})();

--- a/tests/config_paths_relative/_test.js
+++ b/tests/config_paths_relative/_test.js
@@ -1,0 +1,12 @@
+config({
+  paths: {
+    "array": "impl/array"
+  }
+});
+
+go(     ["_reporter", "require", "array"],
+function (amdJS,       require,   array) {
+    amdJS.assert('impl/array' === array.name, 'anon_relative: array.name');
+    amdJS.assert('util' === array.utilName, 'anon_relative: relative to module ID, not URL');
+    amdJS.print('DONE', 'done');
+});

--- a/tests/config_paths_relative/impl/array.js
+++ b/tests/config_paths_relative/impl/array.js
@@ -1,0 +1,6 @@
+define(['./util'], function (util) {
+    return {
+        name: 'impl/array',
+        utilName: util.name
+    };
+});

--- a/tests/config_paths_relative/impl/util.js
+++ b/tests/config_paths_relative/impl/util.js
@@ -1,0 +1,3 @@
+define({
+    name: 'impl/util'
+});

--- a/tests/config_paths_relative/util.js
+++ b/tests/config_paths_relative/util.js
@@ -1,0 +1,3 @@
+define({
+    name: 'util'
+});


### PR DESCRIPTION
This creates 2 new tests:
- **basic_empty_deps** - test `define()` when there is dependencies defined as `undefined` and when dependencies are defined as `[]`
- **config_paths_relative** - test that when relative paths are used, they are relative to the Module ID and not to the module's final-resolved URL.

This changes the following Library Compliance:
- RequireJS - commented `basic` until next rev, which resolves `basic_empty_defs`
- LSJS - commented `basic` until next rev, which resolves `basic_empty_defs`

No current test suites are impacted by `config_paths_relative`.

Referenced Issues:
This is a rollup for #13 #14 #15 #16
